### PR TITLE
fix: Fix padding on extension page identity boxes

### DIFF
--- a/src/user-chrome/new-tabbar-feature/_nav-bar.scss
+++ b/src/user-chrome/new-tabbar-feature/_nav-bar.scss
@@ -35,7 +35,7 @@
   }
 
   // remove box side paddings
-  #identity-box:not(.chromeUI) {
+  #identity-box:not(.chromeUI):not(.extensionPage) {
     #identity-icon-box.identity-box-button {
       padding-inline: unset !important;
     }


### PR DESCRIPTION
Maintain the padding on extension box icons while leaving normal as is.

Before 
<img width="507" alt="{77878F50-E280-469B-ABF8-82F6BE7CC284}" src="https://github.com/user-attachments/assets/07c91819-80bb-457f-91d7-04643a08836f">

After
<img width="348" alt="{EF0A45A9-95F7-4017-9B1D-B4676149F3F7}" src="https://github.com/user-attachments/assets/b7c1fe3f-37e3-491f-b12e-19cb31049eda">


This isn't fully tested so there may be edge cases this borks.