### PR TITLE
fix: Remove incorrect blur drop shadow styling (Version ≥138.0)

### DIFF
--- a/src/user-chrome/components/_menupopup.scss
+++ b/src/user-chrome/components/_menupopup.scss
@@ -82,7 +82,7 @@ toolbarbutton menupopup[placespopup] menuseparator::before {
 @media (-moz-platform: windows) {
   menupopup,
   panel:not(#autoscroller) {
-    --panel-shadow-margin: 12px !important;
+    --panel-shadow-margin: 0 !important;
   }
 }
 


### PR DESCRIPTION
This commit is to fix the context menu (and `<select>` option container) drop shadow that was added partially due to this `userChrome.css` theme for Firefox and partially Firefox 138.0, because they changed some of the context menu styling and shifted some elements around (possibly).

#### Before

![Screenshot of context menu in Firefox with userChrome theme applied; before and after pictures, before picture shown](https://github.com/user-attachments/assets/cb12af53-2c9c-43f2-8a1f-70c3cfe75168)

#### After

![Screenshot of context menu in Firefox with userChrome theme applied; before and after pictures, after picture shown](https://github.com/user-attachments/assets/38108a96-6979-4dc6-a600-e417a82b86b7)
