### PR TITLE
Fix context menus blending with the background, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ To start using MaterialFox UPDATED, follow these steps:
 
    - `toolkit.legacyUserProfileCustomizations.stylesheets`
    - `svg.context-properties.content.enabled`
-   - `layout.css.color-mix.enabled`
 
 4. **Type** `about:support` in the address bar and press <kbd>Enter</kbd>.
 5. **Scroll down** to the `Profile Folder` section and **click** `Open Folder`.

--- a/src/user-chrome/components/_menupopup.scss
+++ b/src/user-chrome/components/_menupopup.scss
@@ -82,7 +82,7 @@ toolbarbutton menupopup[placespopup] menuseparator::before {
 @media (-moz-platform: windows) {
   menupopup,
   panel:not(#autoscroller) {
-    --panel-shadow-margin: 0 !important;
+    --panel-shadow-margin: 12px !important;
   }
 }
 


### PR DESCRIPTION
I think previous PR #123 (merged on May 1st) was incorrect, it removed any separation between context menus and page background.
It's especially visible with the Light theme, see #126.
Please check it on your side. I hope I'm not going crazy here on Windows 10.

Also `layout.css.color-mix.enabled` flag is absent in Firefox because this CSS property became [baseline since 2023](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) or Firefox 113.
It's better to remove it from installation instructions so people aren't confused.