### PR TITLE
Centering the new tab page icon text

### DIFF
--- a/src/user-content/pages/_new-tab.scss
+++ b/src/user-content/pages/_new-tab.scss
@@ -107,6 +107,13 @@
 
   // top sites
   .top-site-outer {
+    display: flex !important;
+    justify-content: center !important;
+    align-items: center !important;
+  }
+
+  .top-site-outer {
+
     .tile {
       border-radius: 100px !important;
       height: 44px !important;


### PR DESCRIPTION
Fix https://github.com/edelvarden/material-fox-updated/issues/101.

If the icon size is modified, the text is not centered with the icon.

To reproduce this issue, simply edit `user-content.css`:
```css
.top-site-outer .tile {
            border-radius: 100px !important;
            height: 84px !important;
            width: 84px !important;
            box-shadow: none !important
        }
 .top-site-outer .tile .icon-wrapper {
            border-radius: 60px !important;
            width: 60px !important;
            height: 60px !important
        }
```

This PR should fix this issue by using Flexbox.
