### PR TITLE
fix: titlebar buttons render incorrectly on windows

### DIFF
--- a/src/global/_reset.scss
+++ b/src/global/_reset.scss
@@ -66,9 +66,9 @@ body {
       --#{$prefix}-font-family: #{meta.inspect($font-family)};
     }
 
-    *,
-    *::before,
-    *::after {
+    *:not(hbox.titlebar-buttonbox, hbox.titlebar-buttonbox *),
+    *:not(hbox.titlebar-buttonbox, hbox.titlebar-buttonbox *)::before,
+    *:not(hbox.titlebar-buttonbox, hbox.titlebar-buttonbox *)::after {
       font-family: var(--#{$prefix}-font-family) !important;
     }
   }


### PR DESCRIPTION
Fixes #137 by disabling the custom font on titlebar buttons